### PR TITLE
Replace _member_ with monasca-user role in the monasca roles

### DIFF
--- a/templates/api-config.yml.j2
+++ b/templates/api-config.yml.j2
@@ -73,7 +73,7 @@ middleware:
   connPoolMinIdleTime: 600000
   connRetryTimes: 2
   connRetryInterval: 50
-  defaultAuthorizedRoles: [user, domainuser, domainadmin,_member_]
+  defaultAuthorizedRoles: [user, domainuser, domainadmin, monasca-user]
   agentAuthorizedRoles: [monasca-agent]
   adminAuthMethod: {{keystone_auth_method}}
   adminUser: {{keystone_admin}}


### PR DESCRIPTION
This allows a simple role to be used to mark users of monascas.
The problem with _member_ is that any user that is part of
project has this role

The change to add this role to the mini-mon user has already been
merged to monasca-vagrant