### PR TITLE
Increase timeout waiting for API port

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,4 +60,4 @@
   service: name=monasca-api state=started enabled=yes
 
 - name: wait for api port
-  wait_for: port={{monasca_api_client_port}} state=started timeout=5
+  wait_for: port={{monasca_api_client_port}} state=started timeout=10


### PR DESCRIPTION
In the monasca-installer vagrant environment, I often see the API
take around 4 to 6 second to open the port.  This change just adds
a bit of leniency.