### PR TITLE
Add mysql parameter to api config template

### DIFF
--- a/templates/api-config.yml.j2
+++ b/templates/api-config.yml.j2
@@ -27,7 +27,7 @@ kafka:
 
 mysql:
   driverClass: com.mysql.jdbc.Driver
-  url: jdbc:mysql://{{mysql_host}}:3306/{{mysql_db}}?connectTimeout=5000&autoReconnect=true&useSSL=true
+  url: jdbc:mysql://{{mysql_host}}:3306/{{mysql_db}}?connectTimeout=5000&autoReconnect=true&useSSL=true&useLegacyDatetimeCode=false
   user: {{mysql_user}}
   password: {{mysql_password}}
   maxWaitForConnection: 1s


### PR DESCRIPTION
This sets the mysql connection to treat timestamps as UTC instead of trying to convert to local time