### PR TITLE
Remove syslog from monasca api appenders

### DIFF
--- a/templates/api-config.yml.j2
+++ b/templates/api-config.yml.j2
@@ -166,10 +166,3 @@ logging:
       archivedFileCount: 5
       timeZone: UTC
       logFormat: # TODO
-
-    - type: syslog
-      host: localhost
-      port: 514
-      facility: local0
-      threshold: ALL
-      logFormat: # TODO


### PR DESCRIPTION
Fix bug jah-1929. Remove syslog from list of log appenders.